### PR TITLE
Make trigger function protect fts field against django updates

### DIFF
--- a/pg_fts/migrations.py
+++ b/pg_fts/migrations.py
@@ -19,7 +19,7 @@ __all__ = ('CreateFTSIndexOperation', 'CreateFTSTriggerOperation',
 
 
 class PgFtsSQL(object):
-    sql_delete_trigger = ("DROP TRIGGER {model}_{fts_name}_update ON \"{model}\";"
+    sql_delete_trigger = ("DROP TRIGGER {model}_{fts_name}_update ON {model};"
                           "DROP FUNCTION {model}_{fts_name}_update()")
 
     sql_create_trigger = """
@@ -38,15 +38,15 @@ BEGIN
 RETURN NEW;
 END;
 $$ LANGUAGE 'plpgsql';
-CREATE TRIGGER {model}_{fts_name}_update BEFORE INSERT OR UPDATE ON \"{model}\"
+CREATE TRIGGER {model}_{fts_name}_update BEFORE INSERT OR UPDATE ON {model}
 FOR EACH ROW EXECUTE PROCEDURE {model}_{fts_name}_update()"""
 
-    sql_create_index = ("CREATE INDEX {model}_{fts_name} ON \"{model}\" "
+    sql_create_index = ("CREATE INDEX {model}_{fts_name} ON {model} "
                         "USING {fts_index}({fts_name})")
 
     sql_delete_index = 'DROP INDEX {model}_{fts_name}'
 
-    sql_update_vector = 'UPDATE \"{model}\" SET {vector} = {fields}'
+    sql_update_vector = 'UPDATE {model} SET {vector} = {fields}'
 
     def delete_trigger(self, model, field):
         return self.sql_delete_trigger.format(

--- a/pg_fts/migrations.py
+++ b/pg_fts/migrations.py
@@ -19,7 +19,7 @@ __all__ = ('CreateFTSIndexOperation', 'CreateFTSTriggerOperation',
 
 
 class PgFtsSQL(object):
-    sql_delete_trigger = ("DROP TRIGGER {model}_{fts_name}_update ON {model};"
+    sql_delete_trigger = ("DROP TRIGGER {model}_{fts_name}_update ON \"{model}\";"
                           "DROP FUNCTION {model}_{fts_name}_update()")
 
     sql_create_trigger = """
@@ -36,15 +36,15 @@ BEGIN
 RETURN NEW;
 END;
 $$ LANGUAGE 'plpgsql';
-CREATE TRIGGER {model}_{fts_name}_update BEFORE INSERT OR UPDATE ON {model}
+CREATE TRIGGER {model}_{fts_name}_update BEFORE INSERT OR UPDATE ON \"{model}\"
 FOR EACH ROW EXECUTE PROCEDURE {model}_{fts_name}_update()"""
 
-    sql_create_index = ("CREATE INDEX {model}_{fts_name} ON {model} "
+    sql_create_index = ("CREATE INDEX {model}_{fts_name} ON \"{model}\" "
                         "USING {fts_index}({fts_name})")
 
     sql_delete_index = 'DROP INDEX {model}_{fts_name}'
 
-    sql_update_vector = 'UPDATE {model} SET {vector} = {fields}'
+    sql_update_vector = 'UPDATE \"{model}\" SET {vector} = {fields}'
 
     def delete_trigger(self, model, field):
         return self.sql_delete_trigger.format(

--- a/pg_fts/migrations.py
+++ b/pg_fts/migrations.py
@@ -31,7 +31,9 @@ BEGIN
     IF TG_OP = 'UPDATE' THEN
         IF {fts_fields} THEN
             new.{fts_name} = {vectors};
-        END IF;
+        ELSE
+            new.{fts_name} = old.{fts_name};
+        END IF; 
     END IF;
 RETURN NEW;
 END;


### PR DESCRIPTION
The current trigger does not work with certain parts of the django ORM.
Specifically if a field is changed after creation and the change does not affect one of the full text indexes columns then the fts field will be set to ''

To reproceudre
call objects.create(..) to create an object
change a non fts column on the object
call .save() again

the UPDATE query from django will now contain `<fts_field> = ''` since '' was the value when .create() saved the object and django does not check for other updates.

Since non of the fts fields has changed the IF clause will block the recalculation of the FTS index and as a result the fts_field will get set to ''.

This simply ensures that the fts field cannot be changed by django